### PR TITLE
Add ASCII art in help command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -404,13 +404,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-lifetimes"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
 name = "is-terminal"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
 dependencies = [
  "hermit-abi",
- "rustix",
+ "rustix 0.38.4",
  "windows-sys",
 ]
 
@@ -437,6 +448,12 @@ checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
 
 [[package]]
 name = "linux-raw-sys"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
+
+[[package]]
+name = "linux-raw-sys"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09fc20d2ca12cb9f044c93e3bd6d32d523e6e2ec3db4f7b2939cd99026ecd3f0"
@@ -455,6 +472,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
+ "terminal_size",
 ]
 
 [[package]]
@@ -725,6 +743,20 @@ dependencies = [
 
 [[package]]
 name = "rustix"
+version = "0.37.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d69718bf81c6127a49dc64e44a742e8bb9213c0ff8869a22c308f84c1d4ab06"
+dependencies = [
+ "bitflags 1.3.2",
+ "errno",
+ "io-lifetimes",
+ "libc",
+ "linux-raw-sys 0.3.8",
+ "windows-sys",
+]
+
+[[package]]
+name = "rustix"
 version = "0.38.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a962918ea88d644592894bc6dc55acc6c0956488adcebbfb6e273506b7fd6e5"
@@ -732,7 +764,7 @@ dependencies = [
  "bitflags 2.3.3",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.4.3",
  "windows-sys",
 ]
 
@@ -826,7 +858,17 @@ dependencies = [
  "cfg-if",
  "fastrand",
  "redox_syscall",
- "rustix",
+ "rustix 0.38.4",
+ "windows-sys",
+]
+
+[[package]]
+name = "terminal_size"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e6bf6f19e9f8ed8d4048dc22981458ebcf406d67e94cd422e5ecd73d63b3237"
+dependencies = [
+ "rustix 0.37.23",
  "windows-sys",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ ring = "0.16.20"
 rpassword = "7.2.0"
 serde = { version = "1.0.174", features = ["derive"] }
 serde_json = "1.0.103"
+terminal_size = "0.2.6"
 
 [dev-dependencies]
 rstest = "0.18.1"

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -1,10 +1,22 @@
 use clap::{builder::PossibleValue, Parser, ValueEnum};
 use std::fmt::Display;
+use terminal_size::{terminal_size, Height, Width};
 
 const DEFAULT_PASSWORD_FILE_NAME: &str = "passwords";
+const ABOUT: &str = "A password manager and generator";
+const ASCII_ART_ABOUT: &str =
+    "\n\n\n\n                                                                                
+@(        🦀🦀🦀🦀🦀  @@@@@@@@  @@     @*  @@@@@@@@  @@@@@@@@  @@@  @@@     
+@(        🦀      🦀  @@        @@@@@@@    @. @@@    @@    @@     @&        
+@@@@@@@@  🦀🦀🦀🦀🦀  @@@@@@@@  @@     @*  @@@@@@@@  @@@@@@@@  @@@  @@@\n\n\n\n";
 
 #[derive(Parser, Debug, PartialEq)]
-#[clap(name = "lockbox", about = "A password manager and generator")]
+#[clap(
+    name = "lockbox",
+    about = if let Some((Width(w), Height(h))) = terminal_size() {
+            if w >= 80 && h >= 10 {format!("{}{}", ASCII_ART_ABOUT, ABOUT)} else {ABOUT.to_string()} } 
+            else {ABOUT.to_string()} 
+)]
 pub struct Args {
     #[clap(subcommand)]
     pub command: Command,


### PR DESCRIPTION
```bash
@(        🦀🦀🦀🦀🦀  @@@@@@@@  @@     @*  @@@@@@@@  @@@@@@@@  @@@  @@@     
@(        🦀     🦀  @@        @@@@@@@    @. @@@    @@    @@     @&        
@@@@@@@@  🦀🦀🦀🦀🦀  @@@@@@@@  @@     @*  @@@@@@@@  @@@@@@@@  @@@  @@@



A password manager and generator

Usage: lockbox <COMMAND>

Commands:
  add       
  generate  Generate a password with the specified properties [default: length=16, symbols=false, uppercase=true, lowercase=true, numbers=true, count=1]
  list      
  remove    
  show      
  help      Print this message or the help of the given subcommand(s)

Options:
  -h, --help  Print help
```