### PR TITLE
added copy password to clipboard for `add` and `generate` commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -120,6 +120,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "630be753d4e58660abd17930c71b647fe46c27ea6b63cc59e1e3851406972e42"
 
 [[package]]
+name = "block"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
+
+[[package]]
 name = "bumpalo"
 version = "3.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -187,6 +193,28 @@ name = "clap_lex"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2da6da31387c7e4ef160ffab6d5e7f00c42626fe39aea70a7b0f1773f7dd6c1b"
+
+[[package]]
+name = "clipboard"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25a904646c0340239dcf7c51677b33928bf24fdf424b79a57909c0109075b2e7"
+dependencies = [
+ "clipboard-win",
+ "objc",
+ "objc-foundation",
+ "objc_id",
+ "x11-clipboard",
+]
+
+[[package]]
+name = "clipboard-win"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a093d6fed558e5fe24c3dfc85a68bb68f1c824f440d3ba5aca189e2998786b"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "colorchoice"
@@ -465,6 +493,7 @@ dependencies = [
  "aes-gcm",
  "anyhow",
  "clap",
+ "clipboard",
  "passwords",
  "ring",
  "rpassword",
@@ -482,10 +511,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b06a4cde4c0f271a446782e3eff8de789548ce57dbc8eca9292c27f4a42004b4"
 
 [[package]]
+name = "malloc_buf"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+
+[[package]]
+name = "objc"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1"
+dependencies = [
+ "malloc_buf",
+]
+
+[[package]]
+name = "objc-foundation"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1add1b659e36c9607c7aab864a76c7a4c2760cd0cd2e120f3fb8b952c7e22bf9"
+dependencies = [
+ "block",
+ "objc",
+ "objc_id",
+]
+
+[[package]]
+name = "objc_id"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c92d4ddb4bd7b50d730c215ff871754d0da6b2178849f8a2a2ab69712d0c073b"
+dependencies = [
+ "objc",
+]
 
 [[package]]
 name = "once_cell"
@@ -1069,3 +1136,22 @@ name = "windows_x86_64_msvc"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
+
+[[package]]
+name = "x11-clipboard"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89bd49c06c9eb5d98e6ba6536cf64ac9f7ee3a009b2f53996d405b3944f6bcea"
+dependencies = [
+ "xcb",
+]
+
+[[package]]
+name = "xcb"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e917a3f24142e9ff8be2414e36c649d47d6cc2ba81f16201cdef96e533e02de"
+dependencies = [
+ "libc",
+ "log",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ rpassword = "7.2.0"
 serde = { version = "1.0.174", features = ["derive"] }
 serde_json = "1.0.103"
 terminal_size = "0.2.6"
+clipboard = "0.5.0"
 
 [dev-dependencies]
 rstest = "0.18.1"

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -17,8 +17,12 @@ pub fn add_password(
     let password = if let Some(password) = password {
         let ctx_result: Result<ClipboardContext, _> = ClipboardProvider::new();
         if let Ok(mut ctx) = ctx_result {
-            ctx.set_contents(password.to_owned()).unwrap();
-            println!("Random password generated and copied to clipboard");
+            if ctx.set_contents(password.to_owned()).is_ok() {
+                println!("Random password generated and copied to clipboard")
+            } else {
+                println!("Random password generated");
+                println!("Note: Failed to copy password to clipboard");
+            }
         }
         password
     } else {
@@ -77,8 +81,12 @@ pub fn generate_password(
             Ok(password) => {
                 let ctx_result: Result<ClipboardContext, _> = ClipboardProvider::new();
                 if let Ok(mut ctx) = ctx_result {
-                    ctx.set_contents(password.to_owned()).unwrap();
-                    println!("{} (Copied to Clipboard)", password)
+                    if ctx.set_contents(password.to_owned()).is_ok() {
+                        println!("{} (Copied to Clipboard)", password);
+                    } else {
+                        println!("{}", password);
+                        println!("Note: Failed to copy password to clipboard");
+                    }
                 } else {
                     println!("{}", password)
                 }


### PR DESCRIPTION
This is related to Issue #31 .
I have used `clipboard` crate to copy the password to clipboard.

In case the clipboard is unavailable, default approach to only present the password is used.

While generating multiple passwords, no password is copied to clipboard.